### PR TITLE
feat: real-time HITL with SSE streaming

### DIFF
--- a/backend/src/Tracewire.Api/Endpoints/HitlStreamEndpoints.cs
+++ b/backend/src/Tracewire.Api/Endpoints/HitlStreamEndpoints.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tracewire.Api.Middleware;
+using Tracewire.Application.Services;
+
+namespace Tracewire.Api.Endpoints;
+
+public static class HitlStreamEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static void MapHitlStreamEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/v1/traces/{traceId:guid}/stream", async (
+            Guid traceId,
+            HttpContext ctx,
+            HitlNotificationService notifications,
+            CancellationToken ct) =>
+        {
+            if (!ctx.HasScope("read:traces"))
+            {
+                ctx.Response.StatusCode = 403;
+                return;
+            }
+
+            ctx.Response.ContentType = "text/event-stream";
+            ctx.Response.Headers.CacheControl = "no-cache";
+            ctx.Response.Headers.Connection = "keep-alive";
+
+            await ctx.Response.WriteAsync(": connected\n\n", ct);
+            await ctx.Response.Body.FlushAsync(ct);
+
+            var reader = notifications.Subscribe(traceId);
+            try
+            {
+                await foreach (var notification in reader.ReadAllAsync(ct))
+                {
+                    var json = JsonSerializer.Serialize(notification, JsonOpts);
+                    await ctx.Response.WriteAsync($"data: {json}\n\n", ct);
+                    await ctx.Response.Body.FlushAsync(ct);
+                }
+            }
+            catch (OperationCanceledException) { }
+            finally
+            {
+                notifications.Unsubscribe(traceId, reader);
+            }
+        }).ExcludeFromDescription();
+    }
+}

--- a/backend/src/Tracewire.Api/Middleware/ApiKeyAuthMiddleware.cs
+++ b/backend/src/Tracewire.Api/Middleware/ApiKeyAuthMiddleware.cs
@@ -18,7 +18,8 @@ public class ApiKeyAuthMiddleware(RequestDelegate next)
         }
 
         var apiKey = context.Request.Headers["X-API-Key"].FirstOrDefault()
-            ?? context.Request.Headers.Authorization.FirstOrDefault()?.Replace("Bearer ", "");
+            ?? context.Request.Headers.Authorization.FirstOrDefault()?.Replace("Bearer ", "")
+            ?? context.Request.Query["apiKey"].FirstOrDefault();
 
         if (string.IsNullOrEmpty(apiKey))
         {

--- a/backend/src/Tracewire.Api/Program.cs
+++ b/backend/src/Tracewire.Api/Program.cs
@@ -7,11 +7,13 @@ using Tracewire.Application.Services;
 using Tracewire.Domain.Entities;
 using Tracewire.Infrastructure;
 
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<TracewireDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+builder.Services.AddSingleton<HitlNotificationService>();
 builder.Services.AddScoped<TraceService>();
 builder.Services.AddScoped<EventService>();
 
@@ -47,6 +49,7 @@ app.MapGet("/v1/health", async (TracewireDbContext db) =>
 
 app.MapTraceEndpoints();
 app.MapEventEndpoints();
+app.MapHitlStreamEndpoints();
 
 using (var scope = app.Services.CreateScope())
 {

--- a/backend/src/Tracewire.Application/Services/EventService.cs
+++ b/backend/src/Tracewire.Application/Services/EventService.cs
@@ -6,7 +6,7 @@ using Tracewire.Infrastructure;
 
 namespace Tracewire.Application.Services;
 
-public class EventService(TracewireDbContext db)
+public class EventService(TracewireDbContext db, HitlNotificationService notifications)
 {
     public async Task<EventResponse?> CreateAsync(CreateEventRequest request, Guid workspaceId)
     {
@@ -74,6 +74,8 @@ public class EventService(TracewireDbContext db)
         evt.HitlStatus = HitlStatus.Paused;
         evt.HitlTimeoutSeconds = request.TimeoutSeconds;
         await db.SaveChangesAsync();
+
+        notifications.Notify(new HitlNotification(evt.Id, evt.TraceId, "Paused", null));
         return true;
     }
 
@@ -92,6 +94,8 @@ public class EventService(TracewireDbContext db)
             resumed_at = DateTime.UtcNow
         });
         await db.SaveChangesAsync();
+
+        notifications.Notify(new HitlNotification(evt.Id, evt.TraceId, "Resumed", evt.HitlDecision));
         return true;
     }
 

--- a/backend/src/Tracewire.Application/Services/HitlNotificationService.cs
+++ b/backend/src/Tracewire.Application/Services/HitlNotificationService.cs
@@ -1,0 +1,56 @@
+using System.Threading.Channels;
+
+namespace Tracewire.Application.Services;
+
+public record HitlNotification(Guid EventId, Guid TraceId, string Status, string? Decision);
+
+public class HitlNotificationService
+{
+    private readonly Lock _lock = new();
+    private readonly Dictionary<Guid, List<Channel<HitlNotification>>> _traceChannels = [];
+
+    public ChannelReader<HitlNotification> Subscribe(Guid traceId)
+    {
+        var channel = Channel.CreateBounded<HitlNotification>(new BoundedChannelOptions(64)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
+
+        lock (_lock)
+        {
+            if (!_traceChannels.TryGetValue(traceId, out var channels))
+            {
+                channels = [];
+                _traceChannels[traceId] = channels;
+            }
+            channels.Add(channel);
+        }
+
+        return channel.Reader;
+    }
+
+    public void Unsubscribe(Guid traceId, ChannelReader<HitlNotification> reader)
+    {
+        lock (_lock)
+        {
+            if (!_traceChannels.TryGetValue(traceId, out var channels)) return;
+            channels.RemoveAll(c => c.Reader == reader);
+            if (channels.Count == 0) _traceChannels.Remove(traceId);
+        }
+    }
+
+    public void Notify(HitlNotification notification)
+    {
+        List<Channel<HitlNotification>>? channels;
+        lock (_lock)
+        {
+            if (!_traceChannels.TryGetValue(notification.TraceId, out channels)) return;
+            channels = [.. channels];
+        }
+
+        foreach (var channel in channels)
+        {
+            channel.Writer.TryWrite(notification);
+        }
+    }
+}

--- a/backend/tests/Tracewire.Api.Tests/ApiTests.cs
+++ b/backend/tests/Tracewire.Api.Tests/ApiTests.cs
@@ -175,4 +175,108 @@ public class ApiTests : IAsyncLifetime
         });
         Assert.Equal(HttpStatusCode.OK, resumeResp.StatusCode);
     }
+
+    [Fact]
+    public async Task SseStream_ReceivesPauseNotification()
+    {
+        var traceResp = await _client.PostAsJsonAsync("/v1/traces", new { agentName = "sse_test" });
+        var trace = await traceResp.Content.ReadFromJsonAsync<TraceResponse>(JsonOpts);
+
+        var eventResp = await _client.PostAsJsonAsync("/v1/events", new
+        {
+            traceId = trace!.Id,
+            eventType = "Prompt",
+            depth = 0
+        });
+        var evt = await eventResp.Content.ReadFromJsonAsync<EventResponse>(JsonOpts);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var sseClient = _factory.CreateClient();
+        sseClient.DefaultRequestHeaders.Add("X-API-Key", TestApiKey);
+        var sseRequest = new HttpRequestMessage(HttpMethod.Get, $"/v1/traces/{trace.Id}/stream");
+        var sseResponse = await sseClient.SendAsync(sseRequest, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        Assert.Equal(HttpStatusCode.OK, sseResponse.StatusCode);
+        Assert.Equal("text/event-stream", sseResponse.Content.Headers.ContentType?.MediaType);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300);
+            await _client.PostAsJsonAsync($"/v1/events/{evt!.Id}/pause", new { timeoutSeconds = 30 });
+        });
+
+        using var stream = await sseResponse.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+        var buffer = "";
+        var received = false;
+
+        while (!cts.IsCancellationRequested)
+        {
+            var chunk = new char[4096];
+            var read = await reader.ReadAsync(chunk.AsMemory(), cts.Token);
+            if (read == 0) break;
+            buffer += new string(chunk, 0, read);
+
+            if (buffer.Contains("\"status\":\"Paused\""))
+            {
+                received = true;
+                break;
+            }
+        }
+
+        Assert.True(received, "Should receive Paused notification via SSE");
+    }
+
+    [Fact]
+    public async Task SseStream_ReceivesResumeNotification()
+    {
+        var traceResp = await _client.PostAsJsonAsync("/v1/traces", new { agentName = "sse_resume_test" });
+        var trace = await traceResp.Content.ReadFromJsonAsync<TraceResponse>(JsonOpts);
+
+        var eventResp = await _client.PostAsJsonAsync("/v1/events", new
+        {
+            traceId = trace!.Id,
+            eventType = "ToolCall",
+            depth = 0
+        });
+        var evt = await eventResp.Content.ReadFromJsonAsync<EventResponse>(JsonOpts);
+
+        await _client.PostAsJsonAsync($"/v1/events/{evt!.Id}/pause", new { timeoutSeconds = 60 });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var sseClient = _factory.CreateClient();
+        sseClient.DefaultRequestHeaders.Add("X-API-Key", TestApiKey);
+        var sseRequest = new HttpRequestMessage(HttpMethod.Get, $"/v1/traces/{trace.Id}/stream");
+        var sseResponse = await sseClient.SendAsync(sseRequest, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300);
+            await _client.PostAsJsonAsync($"/v1/events/{evt.Id}/resume", new
+            {
+                decision = "approve",
+                comments = "auto approved"
+            });
+        });
+
+        using var stream = await sseResponse.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+        var buffer = "";
+        var received = false;
+
+        while (!cts.IsCancellationRequested)
+        {
+            var chunk = new char[4096];
+            var read = await reader.ReadAsync(chunk.AsMemory(), cts.Token);
+            if (read == 0) break;
+            buffer += new string(chunk, 0, read);
+
+            if (buffer.Contains("\"status\":\"Resumed\""))
+            {
+                received = true;
+                break;
+            }
+        }
+
+        Assert.True(received, "Should receive Resumed notification via SSE");
+    }
 }

--- a/frontend/src/hooks/useHitlStream.ts
+++ b/frontend/src/hooks/useHitlStream.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import type { HitlNotification } from "../types";
+
+const BASE = "/v1";
+
+export function useHitlStream(
+  traceId: string | undefined,
+  onNotification: (n: HitlNotification) => void,
+) {
+  const callbackRef = useRef(onNotification);
+  callbackRef.current = onNotification;
+
+  useEffect(() => {
+    if (!traceId) return;
+
+    const apiKey = localStorage.getItem("Tracewire_api_key") ?? "";
+    const url = `${BASE}/traces/${traceId}/stream`;
+    const eventSource = new EventSource(
+      `${url}${url.includes("?") ? "&" : "?"}apiKey=${encodeURIComponent(apiKey)}`,
+    );
+
+    eventSource.onmessage = (e) => {
+      try {
+        const notification: HitlNotification = JSON.parse(e.data);
+        callbackRef.current(notification);
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    return () => eventSource.close();
+  }, [traceId]);
+}

--- a/frontend/src/pages/TraceDetailPage.tsx
+++ b/frontend/src/pages/TraceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getTrace } from "../api/client";
 import type { TraceDetail, TraceEvent } from "../types";
@@ -6,6 +6,7 @@ import DagViewer from "../components/dag/DagViewer";
 import Timeline from "../components/timeline/Timeline";
 import HitlPanel from "../components/hitl/HitlPanel";
 import ReplayControls from "../components/replay/ReplayControls";
+import { useHitlStream } from "../hooks/useHitlStream";
 
 const STATUS_COLORS: Record<string, string> = {
   Running: "text-yellow-400",
@@ -19,15 +20,17 @@ export default function TraceDetailPage() {
   const [selected, setSelected] = useState<TraceEvent | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const loadTrace = () => {
+  const loadTrace = useCallback(() => {
     if (!traceId) return;
     getTrace(traceId)
       .then(setTrace)
       .catch(console.error)
       .finally(() => setLoading(false));
-  };
+  }, [traceId]);
 
-  useEffect(loadTrace, [traceId]);
+  useEffect(loadTrace, [loadTrace]);
+
+  useHitlStream(traceId, loadTrace);
 
   if (loading) return <div className="text-gray-400">Loading trace...</div>;
   if (!trace) return <div className="text-red-400">Trace not found</div>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,3 +53,10 @@ export interface SideEffectWarning {
   sideEffects: string;
   timestamp: string;
 }
+
+export interface HitlNotification {
+  eventId: string;
+  traceId: string;
+  status: string;
+  decision?: string;
+}

--- a/sdk/dotnet/src/Tracewire.Sdk/TraceContext.cs
+++ b/sdk/dotnet/src/Tracewire.Sdk/TraceContext.cs
@@ -61,25 +61,67 @@ public sealed class TraceContext : IAsyncDisposable
 
         await _client.PauseEventAsync(lastEvent.Id, timeoutSeconds);
 
-        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
-        while (DateTime.UtcNow < deadline)
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        try
         {
-            var trace = await _client.GetTraceAsync(TraceId);
-            var evt = trace.Events.FirstOrDefault(e => e.Id == lastEvent.Id);
-            if (evt?.HitlStatus == HitlStatus.Resumed)
+            return await WaitViaSseAsync(lastEvent.Id, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return fallback;
+        }
+    }
+
+    private async Task<string> WaitViaSseAsync(Guid eventId, CancellationToken ct)
+    {
+        var url = $"{_client.BaseUrl}/v1/traces/{TraceId}/stream?apiKey={Uri.EscapeDataString(_client.ApiKey)}";
+        using var http = new HttpClient();
+        using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        resp.EnsureSuccessStatusCode();
+
+        using var stream = await resp.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+        var buffer = "";
+
+        while (!ct.IsCancellationRequested)
+        {
+            var chunk = new char[4096];
+            var read = await reader.ReadAsync(chunk.AsMemory(), ct);
+            if (read == 0) break;
+            buffer += new string(chunk, 0, read);
+
+            while (buffer.Contains("\n\n"))
             {
-                if (evt.HitlDecision is not null)
+                var idx = buffer.IndexOf("\n\n", StringComparison.Ordinal);
+                var message = buffer[..idx];
+                buffer = buffer[(idx + 2)..];
+
+                foreach (var line in message.Split('\n'))
                 {
-                    var doc = JsonDocument.Parse(evt.HitlDecision);
-                    if (doc.RootElement.TryGetProperty("decision", out var dec))
-                        return dec.GetString() ?? "approve";
+                    if (!line.StartsWith("data: ")) continue;
+                    var json = line[6..];
+                    var doc = JsonDocument.Parse(json);
+                    var root = doc.RootElement;
+
+                    if (root.TryGetProperty("eventId", out var eid) &&
+                        eid.GetString() == eventId.ToString() &&
+                        root.TryGetProperty("status", out var status) &&
+                        status.GetString() == "Resumed")
+                    {
+                        if (root.TryGetProperty("decision", out var decisionRaw) &&
+                            decisionRaw.ValueKind == JsonValueKind.String)
+                        {
+                            var decDoc = JsonDocument.Parse(decisionRaw.GetString()!);
+                            if (decDoc.RootElement.TryGetProperty("decision", out var dec))
+                                return dec.GetString() ?? "approve";
+                        }
+                        return "approve";
+                    }
                 }
-                return "approve";
             }
-            await Task.Delay(2000);
         }
 
-        return fallback;
+        throw new OperationCanceledException();
     }
 
     public async ValueTask DisposeAsync()

--- a/sdk/dotnet/src/Tracewire.Sdk/TracewireClient.cs
+++ b/sdk/dotnet/src/Tracewire.Sdk/TracewireClient.cs
@@ -7,6 +7,8 @@ namespace Tracewire.Sdk;
 public class TracewireClient : IDisposable
 {
     private readonly HttpClient _http;
+    internal string BaseUrl { get; }
+    internal string ApiKey { get; }
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -16,7 +18,9 @@ public class TracewireClient : IDisposable
 
     public TracewireClient(string baseUrl = "http://localhost:5185", string apiKey = "")
     {
-        _http = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/')) };
+        BaseUrl = baseUrl.TrimEnd('/');
+        ApiKey = apiKey;
+        _http = new HttpClient { BaseAddress = new Uri(BaseUrl) };
         _http.DefaultRequestHeaders.Add("X-API-Key", apiKey);
     }
 

--- a/sdk/python/tracewire/trace.py
+++ b/sdk/python/tracewire/trace.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
 from tracewire.buffer import EventBuffer
 from tracewire.client import TracewireClient
-from tracewire.models import CreateEventRequest, EventType, HitlStatus
+from tracewire.models import CreateEventRequest, EventType
 
 logger = logging.getLogger("Tracewire")
 
@@ -68,20 +67,33 @@ class TraceContext:
 
         await self._client.pause_event(event_id, timeout)
 
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            trace_data = await self._client.get_trace(self.trace_id)
-            for event in trace_data.get("events", []):
-                if event.get("id") == str(event_id) and event.get("hitlStatus") == HitlStatus.RESUMED:
-                    decision_raw = event.get("hitlDecision")
-                    if decision_raw:
-                        decision = json.loads(decision_raw) if isinstance(decision_raw, str) else decision_raw
-                        return decision.get("decision", "approve")
-                    return "approve"
-            await asyncio.sleep(2)
+        try:
+            return await asyncio.wait_for(
+                self._wait_via_sse(event_id), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            logger.warning("HITL timeout reached, applying fallback: %s", fallback)
+            return fallback
 
-        logger.warning("HITL timeout reached, applying fallback: %s", fallback)
-        return fallback
+    async def _wait_via_sse(self, event_id: UUID) -> str:
+        url = f"{self._client._base_url}/v1/traces/{self.trace_id}/stream"
+        params = {"apiKey": self._client._api_key}
+        async with self._client._http.stream("GET", url, params=params) as resp:
+            buffer = ""
+            async for chunk in resp.aiter_text():
+                buffer += chunk
+                while "\n\n" in buffer:
+                    message, buffer = buffer.split("\n\n", 1)
+                    for line in message.split("\n"):
+                        if line.startswith("data: "):
+                            data = json.loads(line[6:])
+                            if data.get("eventId") == str(event_id) and data.get("status") == "Resumed":
+                                decision_raw = data.get("decision")
+                                if decision_raw:
+                                    decision = json.loads(decision_raw) if isinstance(decision_raw, str) else decision_raw
+                                    return decision.get("decision", "approve")
+                                return "approve"
+        return "approve"
 
 
 @asynccontextmanager

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -7,8 +7,8 @@ import type {
 } from "./models.js";
 
 export class TracewireClient {
-  private baseUrl: string;
-  private apiKey: string;
+  readonly baseUrl: string;
+  readonly apiKey: string;
 
   constructor(baseUrl = "http://localhost:5185", apiKey = "") {
     this.baseUrl = baseUrl.replace(/\/$/, "");

--- a/sdk/typescript/src/trace.ts
+++ b/sdk/typescript/src/trace.ts
@@ -56,21 +56,56 @@ export class TraceContext {
 
     await this.client.pauseEvent(eventId, timeout);
 
-    const deadline = Date.now() + timeout * 1000;
-    while (Date.now() < deadline) {
-      const traceData = await this.client.getTrace(this.traceId);
-      const event = traceData.events?.find((e) => e.id === eventId);
-      if (event?.hitlStatus === "Resumed") {
-        if (event.hitlDecision) {
-          const decision = JSON.parse(event.hitlDecision);
-          return decision.decision ?? "approve";
-        }
-        return "approve";
-      }
-      await new Promise((r) => setTimeout(r, 2000));
-    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout * 1000);
 
-    return fallback;
+    try {
+      return await this.waitViaSse(eventId, controller.signal);
+    } catch {
+      return fallback;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async waitViaSse(eventId: string, signal: AbortSignal): Promise<string> {
+    const url = `${this.client.baseUrl}/v1/traces/${this.traceId}/stream?apiKey=${encodeURIComponent(this.client.apiKey)}`;
+    const resp = await fetch(url, { signal });
+    if (!resp.ok || !resp.body) throw new Error("SSE connection failed");
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        while (buffer.includes("\n\n")) {
+          const idx = buffer.indexOf("\n\n");
+          const message = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+
+          for (const line of message.split("\n")) {
+            if (line.startsWith("data: ")) {
+              const data = JSON.parse(line.slice(6));
+              if (data.eventId === eventId && data.status === "Resumed") {
+                if (data.decision) {
+                  const decision = JSON.parse(data.decision);
+                  return decision.decision ?? "approve";
+                }
+                return "approve";
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    throw new Error("SSE stream ended without resume");
   }
 }
 


### PR DESCRIPTION
- Add HitlNotificationService (in-memory Channel-based pub/sub)
- Add SSE endpoint GET /v1/traces/{traceId}/stream
- Emit notifications on pause/resume in EventService
- Support apiKey query param in auth middleware for EventSource
- Add useHitlStream hook for live frontend updates
- Replace polling with SSE in all 3 SDKs (Python, TypeScript, .NET)
- Add SSE integration tests