### PR TITLE
feat: SDK-side replay execution via SSE

### DIFF
--- a/backend/src/Tracewire.Application/Services/EventService.cs
+++ b/backend/src/Tracewire.Application/Services/EventService.cs
@@ -61,6 +61,9 @@ public class EventService(TracewireDbContext db, HitlNotificationService notific
         db.Events.Add(newEvent);
         await db.SaveChangesAsync();
 
+        notifications.Notify(new HitlNotification(
+            newEvent.Id, sourceEvent.TraceId, "Replay", null, branchName, newEvent.Payload));
+
         return new ReplayResponse(newEvent.Id, branchName, warnings);
     }
 

--- a/backend/src/Tracewire.Application/Services/HitlNotificationService.cs
+++ b/backend/src/Tracewire.Application/Services/HitlNotificationService.cs
@@ -2,7 +2,7 @@ using System.Threading.Channels;
 
 namespace Tracewire.Application.Services;
 
-public record HitlNotification(Guid EventId, Guid TraceId, string Status, string? Decision);
+public record HitlNotification(Guid EventId, Guid TraceId, string Status, string? Decision, string? BranchName = null, string? Payload = null);
 
 public class HitlNotificationService
 {

--- a/backend/tests/Tracewire.Api.Tests/ApiTests.cs
+++ b/backend/tests/Tracewire.Api.Tests/ApiTests.cs
@@ -279,4 +279,57 @@ public class ApiTests : IAsyncLifetime
 
         Assert.True(received, "Should receive Resumed notification via SSE");
     }
+
+    [Fact]
+    public async Task SseStream_ReceivesReplayNotification()
+    {
+        var traceResp = await _client.PostAsJsonAsync("/v1/traces", new { agentName = "sse_replay_test" });
+        var trace = await traceResp.Content.ReadFromJsonAsync<TraceResponse>(JsonOpts);
+
+        var eventResp = await _client.PostAsJsonAsync("/v1/events", new
+        {
+            traceId = trace!.Id,
+            eventType = "Prompt",
+            depth = 0,
+            payload = "{\"prompt\":\"original\"}"
+        });
+        var evt = await eventResp.Content.ReadFromJsonAsync<EventResponse>(JsonOpts);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var sseClient = _factory.CreateClient();
+        sseClient.DefaultRequestHeaders.Add("X-API-Key", TestApiKey);
+        var sseRequest = new HttpRequestMessage(HttpMethod.Get, $"/v1/traces/{trace.Id}/stream");
+        var sseResponse = await sseClient.SendAsync(sseRequest, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300);
+            await _client.PostAsJsonAsync($"/v1/events/{evt!.Id}/replay", new
+            {
+                modifiedPayload = "{\"prompt\":\"modified\"}",
+                newBranchName = "replay_test_branch"
+            });
+        });
+
+        using var stream = await sseResponse.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+        var buffer = "";
+        var received = false;
+
+        while (!cts.IsCancellationRequested)
+        {
+            var chunk = new char[4096];
+            var read = await reader.ReadAsync(chunk.AsMemory(), cts.Token);
+            if (read == 0) break;
+            buffer += new string(chunk, 0, read);
+
+            if (buffer.Contains("\"status\":\"Replay\"") && buffer.Contains("replay_test_branch"))
+            {
+                received = true;
+                break;
+            }
+        }
+
+        Assert.True(received, "Should receive Replay notification via SSE with branch name");
+    }
 }

--- a/sdk/dotnet/src/Tracewire.Sdk/TraceContext.cs
+++ b/sdk/dotnet/src/Tracewire.Sdk/TraceContext.cs
@@ -8,6 +8,8 @@ public sealed class TraceContext : IAsyncDisposable
     private readonly EventBuffer _buffer;
     private readonly bool _snapshot;
     private int _depth;
+    private CancellationTokenSource? _replayCts;
+    private Task? _replayTask;
 
     public Guid TraceId { get; }
 
@@ -124,8 +126,69 @@ public sealed class TraceContext : IAsyncDisposable
         throw new OperationCanceledException();
     }
 
+    public void OnReplay(Func<string, string?, string, Task> callback)
+    {
+        _replayCts = new CancellationTokenSource();
+        _replayTask = ListenForReplaysAsync(callback, _replayCts.Token);
+    }
+
+    private async Task ListenForReplaysAsync(Func<string, string?, string, Task> callback, CancellationToken ct)
+    {
+        var url = $"{_client.BaseUrl}/v1/traces/{TraceId}/stream?apiKey={Uri.EscapeDataString(_client.ApiKey)}";
+        using var http = new HttpClient();
+        try
+        {
+            using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+            resp.EnsureSuccessStatusCode();
+
+            using var stream = await resp.Content.ReadAsStreamAsync(ct);
+            using var reader = new StreamReader(stream);
+            var buffer = "";
+
+            while (!ct.IsCancellationRequested)
+            {
+                var chunk = new char[4096];
+                var read = await reader.ReadAsync(chunk.AsMemory(), ct);
+                if (read == 0) break;
+                buffer += new string(chunk, 0, read);
+
+                while (buffer.Contains("\n\n"))
+                {
+                    var idx = buffer.IndexOf("\n\n", StringComparison.Ordinal);
+                    var message = buffer[..idx];
+                    buffer = buffer[(idx + 2)..];
+
+                    foreach (var line in message.Split('\n'))
+                    {
+                        if (!line.StartsWith("data: ")) continue;
+                        var json = line[6..];
+                        var doc = JsonDocument.Parse(json);
+                        var root = doc.RootElement;
+
+                        if (root.TryGetProperty("status", out var status) &&
+                            status.GetString() == "Replay")
+                        {
+                            var branchName = root.TryGetProperty("branchName", out var bn) ? bn.GetString() ?? "" : "";
+                            var payload = root.TryGetProperty("payload", out var pl) ? pl.GetString() : null;
+                            var eventId = root.TryGetProperty("eventId", out var eid) ? eid.GetString() ?? "" : "";
+                            await callback(branchName, payload, eventId);
+                        }
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
     public async ValueTask DisposeAsync()
     {
+        if (_replayCts is not null)
+        {
+            await _replayCts.CancelAsync();
+            if (_replayTask is not null)
+                try { await _replayTask; } catch (OperationCanceledException) { }
+            _replayCts.Dispose();
+        }
         await _buffer.StopAsync();
     }
 }

--- a/sdk/python/tracewire/trace.py
+++ b/sdk/python/tracewire/trace.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Callable, Awaitable
 from uuid import UUID
 
 from tracewire.buffer import EventBuffer
@@ -12,6 +12,8 @@ from tracewire.client import TracewireClient
 from tracewire.models import CreateEventRequest, EventType
 
 logger = logging.getLogger("Tracewire")
+
+ReplayCallback = Callable[[str, str | None, str], Awaitable[None]]
 
 
 class TraceContext:
@@ -22,6 +24,8 @@ class TraceContext:
         self._snapshot = snapshot
         self._last_event_id: UUID | None = None
         self._depth = 0
+        self._replay_callback: ReplayCallback | None = None
+        self._sse_task: asyncio.Task | None = None
 
     def log_event(
         self,
@@ -95,6 +99,41 @@ class TraceContext:
                                 return "approve"
         return "approve"
 
+    def on_replay(self, callback: ReplayCallback) -> None:
+        self._replay_callback = callback
+        self._sse_task = asyncio.ensure_future(self._listen_for_replays())
+
+    async def _listen_for_replays(self) -> None:
+        url = f"{self._client._base_url}/v1/traces/{self.trace_id}/stream"
+        params = {"apiKey": self._client._api_key}
+        try:
+            async with self._client._http.stream("GET", url, params=params) as resp:
+                buffer = ""
+                async for chunk in resp.aiter_text():
+                    buffer += chunk
+                    while "\n\n" in buffer:
+                        message, buffer = buffer.split("\n\n", 1)
+                        for line in message.split("\n"):
+                            if not line.startswith("data: "):
+                                continue
+                            data = json.loads(line[6:])
+                            if data.get("status") == "Replay" and self._replay_callback:
+                                await self._replay_callback(
+                                    data.get("branchName", ""),
+                                    data.get("payload"),
+                                    data.get("eventId", ""),
+                                )
+        except Exception:
+            logger.debug("Replay SSE listener stopped")
+
+    async def stop_replay_listener(self) -> None:
+        if self._sse_task and not self._sse_task.done():
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except asyncio.CancelledError:
+                pass
+
 
 @asynccontextmanager
 async def trace(
@@ -107,6 +146,7 @@ async def trace(
     client = TracewireClient(base_url=base_url, api_key=api_key)
     buffer = EventBuffer(client)
     await buffer.start()
+    ctx: TraceContext | None = None
 
     try:
         trace_resp = await client.create_trace(agent_name, metadata=metadata)
@@ -116,5 +156,7 @@ async def trace(
         logger.exception("Trace failed: %s", exc)
         raise
     finally:
+        if ctx:
+            await ctx.stop_replay_listener()
         await buffer.stop()
         await client.close()

--- a/sdk/typescript/src/trace.ts
+++ b/sdk/typescript/src/trace.ts
@@ -2,6 +2,8 @@ import type { CreateEventRequest, EventType } from "./models.js";
 import { TracewireClient } from "./client.js";
 import { EventBuffer } from "./buffer.js";
 
+export type ReplayCallback = (branchName: string, payload: string | undefined, eventId: string) => Promise<void>;
+
 export class TraceContext {
   private client: TracewireClient;
   private buffer: EventBuffer;
@@ -9,6 +11,7 @@ export class TraceContext {
   private snapshot: boolean;
   private lastEventId: string | undefined;
   private depth = 0;
+  private replayAbort: AbortController | null = null;
 
   constructor(client: TracewireClient, buffer: EventBuffer, traceId: string, snapshot = false) {
     this.client = client;
@@ -107,6 +110,50 @@ export class TraceContext {
     }
     throw new Error("SSE stream ended without resume");
   }
+
+  onReplay(callback: ReplayCallback): void {
+    this.replayAbort = new AbortController();
+    this.listenForReplays(callback, this.replayAbort.signal);
+  }
+
+  private async listenForReplays(callback: ReplayCallback, signal: AbortSignal): Promise<void> {
+    const url = `${this.client.baseUrl}/v1/traces/${this.traceId}/stream?apiKey=${encodeURIComponent(this.client.apiKey)}`;
+    try {
+      const resp = await fetch(url, { signal });
+      if (!resp.ok || !resp.body) return;
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        while (buffer.includes("\n\n")) {
+          const idx = buffer.indexOf("\n\n");
+          const message = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+
+          for (const line of message.split("\n")) {
+            if (!line.startsWith("data: ")) continue;
+            const data = JSON.parse(line.slice(6));
+            if (data.status === "Replay") {
+              await callback(data.branchName ?? "", data.payload, data.eventId ?? "");
+            }
+          }
+        }
+      }
+    } catch {
+      // listener stopped
+    }
+  }
+
+  stopReplayListener(): void {
+    this.replayAbort?.abort();
+    this.replayAbort = null;
+  }
 }
 
 export async function trace<T>(
@@ -121,7 +168,11 @@ export async function trace<T>(
   try {
     const traceResp = await client.createTrace(agentName);
     const ctx = new TraceContext(client, buffer, traceResp.id, options?.snapshot);
-    return await fn(ctx);
+    try {
+      return await fn(ctx);
+    } finally {
+      ctx.stopReplayListener();
+    }
   } finally {
     await buffer.stop();
   }


### PR DESCRIPTION
- Extend HitlNotification with branchName/payload for replay events
- Emit Replay notification from EventService.ReplayAsync
- Python SDK: add on_replay(callback) with background SSE listener
- TypeScript SDK: add onReplay(callback) with fetch-based SSE listener
- .NET SDK: add OnReplay(callback) with HttpClient SSE listener
- All SDKs auto-cleanup listener on dispose
- Add SSE replay notification integration test