### PR TITLE
feat: production-quality framework adapters (#3)

### DIFF
--- a/sdk/python/tracewire/__init__.py
+++ b/sdk/python/tracewire/__init__.py
@@ -1,5 +1,18 @@
 from tracewire.client import TracewireClient
 from tracewire.trace import trace
 from tracewire.models import TraceStatus, EventType
+from tracewire.adapters import TracewireAdapter
+from tracewire.adapters.langchain import TracewireLangChainCallback
+from tracewire.adapters.autogen import TracewireAutoGenMiddleware
+from tracewire.adapters.crewai import TracewireCrewAICallback
 
-__all__ = ["TracewireClient", "trace", "TraceStatus", "EventType"]
+__all__ = [
+    "TracewireClient",
+    "trace",
+    "TraceStatus",
+    "EventType",
+    "TracewireAdapter",
+    "TracewireLangChainCallback",
+    "TracewireAutoGenMiddleware",
+    "TracewireCrewAICallback",
+]

--- a/sdk/python/tracewire/adapters/__init__.py
+++ b/sdk/python/tracewire/adapters/__init__.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import Any
 
 from tracewire.models import EventType
 from tracewire.trace import TraceContext
 
 
-class TracewireAdapter(ABC):
+class TracewireAdapter:
     def __init__(self, ctx: TraceContext):
         self._ctx = ctx
 

--- a/sdk/python/tracewire/adapters/autogen.py
+++ b/sdk/python/tracewire/adapters/autogen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from tracewire.adapters import TracewireAdapter
@@ -16,17 +17,27 @@ class TracewireAutoGenMiddleware:
     """
 
     def __init__(self, ctx: TraceContext):
-        self._adapter = TracewireAdapter.__new__(TracewireAdapter)
-        self._adapter._ctx = ctx
+        self._adapter = TracewireAdapter(ctx)
+        self._msg_start_time: float | None = None
+        self._tool_start_times: dict[str, float] = {}
 
     async def on_message(self, message: Any, sender: Any, **kwargs: Any) -> None:
+        self._msg_start_time = time.monotonic()
         self._adapter.on_llm_start(str(message), sender=str(sender))
 
     async def on_response(self, response: Any, **kwargs: Any) -> None:
-        self._adapter.on_llm_end(str(response))
+        latency_ms = None
+        if self._msg_start_time is not None:
+            latency_ms = int((time.monotonic() - self._msg_start_time) * 1000)
+            self._msg_start_time = None
+        self._adapter.on_llm_end(str(response), latency_ms=latency_ms)
 
     async def on_tool_call(self, tool_name: str, arguments: Any, **kwargs: Any) -> None:
+        self._tool_start_times[tool_name] = time.monotonic()
         self._adapter.on_tool_start(tool_name, arguments)
 
     async def on_tool_result(self, tool_name: str, result: Any, **kwargs: Any) -> None:
-        self._adapter.on_tool_end(tool_name, result)
+        latency_ms = None
+        if tool_name in self._tool_start_times:
+            latency_ms = int((time.monotonic() - self._tool_start_times.pop(tool_name)) * 1000)
+        self._adapter.on_tool_end(tool_name, result, latency_ms=latency_ms)

--- a/sdk/python/tracewire/adapters/crewai.py
+++ b/sdk/python/tracewire/adapters/crewai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from tracewire.adapters import TracewireAdapter
@@ -10,14 +11,14 @@ class TracewireCrewAICallback:
     """CrewAI step callback adapter.
 
     Usage:
-        from tracewire.adapters.crewai import tracewireCrewAICallback
+        from tracewire.adapters.crewai import TracewireCrewAICallback
         callback = TracewireCrewAICallback(trace_context)
         crew = Crew(..., step_callback=callback.on_step)
     """
 
     def __init__(self, ctx: TraceContext):
-        self._adapter = TracewireAdapter.__new__(TracewireAdapter)
-        self._adapter._ctx = ctx
+        self._adapter = TracewireAdapter(ctx)
+        self._task_start_time: float | None = None
 
     def on_step(self, step_output: Any) -> None:
         step_str = str(step_output)
@@ -27,7 +28,12 @@ class TracewireCrewAICallback:
             self._adapter.on_llm_end(step_str)
 
     def on_task_start(self, task: Any) -> None:
+        self._task_start_time = time.monotonic()
         self._adapter.on_llm_start(str(task))
 
     def on_task_end(self, task: Any, output: Any) -> None:
-        self._adapter.on_llm_end(str(output))
+        latency_ms = None
+        if self._task_start_time is not None:
+            latency_ms = int((time.monotonic() - self._task_start_time) * 1000)
+            self._task_start_time = None
+        self._adapter.on_llm_end(str(output), latency_ms=latency_ms)

--- a/sdk/python/tracewire/adapters/langchain.py
+++ b/sdk/python/tracewire/adapters/langchain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import time
 from typing import Any
+from uuid import UUID
 
 from tracewire.adapters import TracewireAdapter
 from tracewire.trace import TraceContext
@@ -16,29 +18,46 @@ class TracewireLangChainCallback:
     """
 
     def __init__(self, ctx: TraceContext):
-        self._adapter = TracewireAdapter.__new__(TracewireAdapter)
-        self._adapter._ctx = ctx
+        self._adapter = TracewireAdapter(ctx)
+        self._llm_start_time: float | None = None
+        self._tool_names: dict[UUID, str] = {}
+        self._tool_start_times: dict[UUID, float] = {}
 
     def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
+        self._llm_start_time = time.monotonic()
         for prompt in prompts:
             self._adapter.on_llm_start(prompt, serialized_info=str(serialized))
 
     def on_llm_end(self, response: Any, **kwargs: Any) -> None:
-        text = str(response)
-        self._adapter.on_llm_end(text)
+        latency_ms = None
+        if self._llm_start_time is not None:
+            latency_ms = int((time.monotonic() - self._llm_start_time) * 1000)
+            self._llm_start_time = None
+        self._adapter.on_llm_end(str(response), latency_ms=latency_ms)
 
     def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
+        self._llm_start_time = None
         if isinstance(error, Exception):
             self._adapter.on_error(error)
 
-    def on_tool_start(self, serialized: dict[str, Any], input_str: str, **kwargs: Any) -> None:
+    def on_tool_start(self, serialized: dict[str, Any], input_str: str, *, run_id: UUID | None = None, **kwargs: Any) -> None:
         tool_name = serialized.get("name", "unknown")
+        if run_id:
+            self._tool_names[run_id] = tool_name
+            self._tool_start_times[run_id] = time.monotonic()
         self._adapter.on_tool_start(tool_name, input_str)
 
-    def on_tool_end(self, output: str, **kwargs: Any) -> None:
-        self._adapter.on_tool_end("unknown", output)
+    def on_tool_end(self, output: str, *, run_id: UUID | None = None, **kwargs: Any) -> None:
+        tool_name = self._tool_names.pop(run_id, "unknown") if run_id else "unknown"
+        latency_ms = None
+        if run_id and run_id in self._tool_start_times:
+            latency_ms = int((time.monotonic() - self._tool_start_times.pop(run_id)) * 1000)
+        self._adapter.on_tool_end(tool_name, output, latency_ms=latency_ms)
 
-    def on_tool_error(self, error: BaseException, **kwargs: Any) -> None:
+    def on_tool_error(self, error: BaseException, *, run_id: UUID | None = None, **kwargs: Any) -> None:
+        if run_id:
+            self._tool_names.pop(run_id, None)
+            self._tool_start_times.pop(run_id, None)
         if isinstance(error, Exception):
             self._adapter.on_error(error)
 

--- a/sdk/typescript/src/adapters/langchain.ts
+++ b/sdk/typescript/src/adapters/langchain.ts
@@ -1,28 +1,50 @@
 import type { TraceContext } from "../trace.js";
-import { createAdapter, type TracewireAdapter } from "./base.js";
+import { createAdapter } from "./base.js";
 
 export function createLangChainCallback(ctx: TraceContext) {
   const adapter = createAdapter(ctx);
+  let llmStartTime: number | undefined;
+  const toolNames = new Map<string, string>();
+  const toolStartTimes = new Map<string, number>();
 
   return {
     handleLLMStart(_llm: unknown, prompts: string[]) {
+      llmStartTime = Date.now();
       for (const prompt of prompts) {
         adapter.onLlmStart(prompt);
       }
     },
     handleLLMEnd(output: unknown) {
-      adapter.onLlmEnd(String(output));
+      const latencyMs = llmStartTime !== undefined ? Date.now() - llmStartTime : undefined;
+      llmStartTime = undefined;
+      adapter.onLlmEnd(String(output), latencyMs);
     },
     handleLLMError(err: Error) {
+      llmStartTime = undefined;
       adapter.onError(err);
     },
-    handleToolStart(_tool: unknown, input: string) {
-      adapter.onToolStart("unknown", input);
+    handleToolStart(tool: Record<string, unknown>, input: string, runId?: string) {
+      const toolName = (tool?.name as string) ?? "unknown";
+      if (runId) {
+        toolNames.set(runId, toolName);
+        toolStartTimes.set(runId, Date.now());
+      }
+      adapter.onToolStart(toolName, input);
     },
-    handleToolEnd(output: string) {
-      adapter.onToolEnd("unknown", output);
+    handleToolEnd(output: string, runId?: string) {
+      const toolName = runId ? (toolNames.get(runId) ?? "unknown") : "unknown";
+      const latencyMs = runId && toolStartTimes.has(runId) ? Date.now() - toolStartTimes.get(runId)! : undefined;
+      if (runId) {
+        toolNames.delete(runId);
+        toolStartTimes.delete(runId);
+      }
+      adapter.onToolEnd(toolName, output, latencyMs);
     },
-    handleToolError(err: Error) {
+    handleToolError(err: Error, runId?: string) {
+      if (runId) {
+        toolNames.delete(runId);
+        toolStartTimes.delete(runId);
+      }
       adapter.onError(err);
     },
   };

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,8 @@
 export { TracewireClient } from "./client.js";
 export { EventBuffer } from "./buffer.js";
 export { TraceContext, trace } from "./trace.js";
+export { createAdapter } from "./adapters/base.js";
+export type { TracewireAdapter } from "./adapters/base.js";
+export { wrapLanguageModel } from "./adapters/ai-sdk.js";
+export { createLangChainCallback } from "./adapters/langchain.js";
 export type * from "./models.js";


### PR DESCRIPTION
- Fix Python adapters: proper __init__ instead of __new__ hack
- Add latency tracking to LangChain, AutoGen, CrewAI adapters
- Add tool name tracking via run_id in LangChain (Python + TypeScript)
- Add adapter re-exports in Python __init__.py and TypeScript index.ts
- .NET adapters already production-ready (Stopwatch, proper tool names)